### PR TITLE
SUKU added header table as first argument of rtmrx_cb

### DIFF
--- a/common/src/c/grid_decode.c
+++ b/common/src/c/grid_decode.c
@@ -400,7 +400,18 @@ uint8_t grid_decode_midi_rtm_to_ui(char* header, char* chunk) {
 
   size_t result_len = lua_rawlen(L, -1);
 
+  lua_newtable(L);
+
+  size_t idx = 0;
+
+  lua_pushinteger(L, grid_msg_get_parameter_raw((uint8_t*)chunk, INSTR));
+  lua_rawseti(L, -2, ++idx);
+  lua_pushinteger(L, grid_msg_get_parameter_raw((uint8_t*)header, BRC_SX));
+  lua_rawseti(L, -2, ++idx);
+  lua_pushinteger(L, grid_msg_get_parameter_raw((uint8_t*)header, BRC_SY));
+  lua_rawseti(L, -2, ++idx);
   lua_pushinteger(L, grid_msg_get_parameter_raw((uint8_t*)chunk, CLASS_MIDIRTM_BYTE));
+  lua_rawseti(L, -2, ++idx);
   lua_rawseti(L, -2, result_len + 1);
 
   size_t order_len = lua_rawlen(L, -2);

--- a/common/src/lua/decode.lua
+++ b/common/src/lua/decode.lua
@@ -39,9 +39,9 @@ pass_event = function(el, x)
   end
 end
 
-pass_rtm = function(el, rtm_type)
+pass_rtm = function(el, x)
   if el.rtmrx_cb then
-    el:rtmrx_cb(rtm_type)
+    el:rtmrx_cb({ x[1], x[2], x[3] }, x[4])
   end
 end
 


### PR DESCRIPTION
## Changes
RTM RX callback missing header parameter added.

## Test instructions
```
-- rx_mode(int type [, int mode]) Get or set RX routing. 
-- type: 0=MIDIVOICE 1=MIDISYSEX 2=MIDIRTM 3=EVENTVIEW. 
-- mode: bitmask 0x01=forward_from_usb 0x02=handle_external 0x04=handle_internal

-- Eaxmple: enable handling and forwarding of clock messages received from USB
-- Note: must be added to USB connected Grid module only
rx_mode(2, 0x01 | 0x02)

-- Example: enable handling of clock messages received via Grid connection
-- Note: must be added to all modules on the Grid
rx_mode(2, 0x02)

-- Example: callback for printing received clock messages
self.rtmrx_cb = function(self, header, rtm_byte)
  print("RTM RX: "..rtm_byte)
end
```

## Generate test RTM stream on linux
```amidi -p hw:1,0,0 -S "F8 F8 F8 FA FC F8 F8 F8 FE FF"```