### PR TITLE
SUKU fix empty CONFIG execute not persisted by STORE

### DIFF
--- a/common/src/c/grid_ui.c
+++ b/common/src/c/grid_ui.c
@@ -384,10 +384,6 @@ int grid_ui_register_script(struct grid_ui_model* ui, uint8_t element, uint8_t e
 
   assert(script);
 
-  if (!script[0]) {
-    return 1;
-  }
-
   char temp[GRID_PARAMETER_ACTIONSTRING_maxlength + 100] = {0};
 
   grid_ui_script_header(ele->index, eve->function_name, temp);


### PR DESCRIPTION
## Summary

- `grid_ui_register_script` had an early return for empty scripts (`if (!script[0]) return 1`) that exited before setting `cfg_changed_flag = 1`
- With the flag never set, `grid_ui_bulk_page_store` skipped those events entirely, so nothing was written/deleted in NVM
- Removing the early return lets empty scripts flow through: a valid no-op Lua function is registered, the flag is set, and STORE persists the `.cfg` file correctly

## Test plan

- [ ] Send CONFIG execute with empty action string for an event
- [ ] Verify ACK is returned
- [ ] Send STORE command
- [ ] Power-cycle the device and confirm the event has no action (empty/no-op) on reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)