### PR TITLE
fix: release title timestamp missing

### DIFF
--- a/.github/workflows/build-and-push-firmware.yml
+++ b/.github/workflows/build-and-push-firmware.yml
@@ -50,7 +50,8 @@ jobs:
 
       - name: Set timestamp in environment and output
         run: |
-          echo "ACTION_DATE=$(date +'%Y-%m-%d-%H%M')" >> $GITHUB_ENV
+          ACTION_DATE=$(date +'%Y-%m-%d-%H%M')
+          echo "ACTION_DATE=$ACTION_DATE" >> $GITHUB_ENV
           echo "timestamp=$ACTION_DATE" >> $GITHUB_OUTPUT
 
       - name: Copy and rename artifacts


### PR DESCRIPTION
## Summary
- Fixes #384
- `GITHUB_ENV` values set in a `run` block are only available to *subsequent* steps, not within the same block. The output step was writing `timestamp=$ACTION_DATE` where `$ACTION_DATE` was still empty, resulting in a blank timestamp in the release title.
- Fix captures the date in a local shell variable first, then writes it to both `$GITHUB_ENV` and `$GITHUB_OUTPUT`.

## Test plan
- [ ] Trigger a tag-based release and confirm the release title includes the date, e.g. `grid v1.x.x (2026-06-13-1430)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)