### PR TITLE
fix: add missing step id for release timestamp

### DIFF
--- a/.github/workflows/build-and-push-firmware.yml
+++ b/.github/workflows/build-and-push-firmware.yml
@@ -49,6 +49,7 @@ jobs:
           sh -c "./wasm_build.sh"
 
       - name: Set timestamp in environment and output
+        id: set_out
         run: |
           ACTION_DATE=$(date +'%Y-%m-%d-%H%M')
           echo "ACTION_DATE=$ACTION_DATE" >> $GITHUB_ENV


### PR DESCRIPTION
## Summary
- Fixes the release title timestamp still being blank after PR #385
- PR #385 fixed the shell variable but missed the root cause: the step had no `id: set_out`, so `steps.set_out.outputs.timestamp` on line 21 always resolved to empty regardless of what was written to `$GITHUB_OUTPUT`
- Adds `id: set_out` to the timestamp step

## Test plan
- [ ] Trigger a tag-based release and confirm the release title includes the date, e.g. `grid v1.x.x (2026-06-15-1430)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)