### PR TITLE
Fix GRID_ACTIONSTRING_TOUCH_INIT minification mismatch

### DIFF
--- a/common/src/c/grid_ui_touch.h
+++ b/common/src/c/grid_ui_touch.h
@@ -67,7 +67,7 @@ extern const luaL_Reg GRID_LUA_T_INDEX_META[];
   \
   "}}"
 
-#define GRID_ACTIONSTRING_TOUCH_INIT "--[[@cb]] self.touch_cb=function(self,id,evt,x,y)print(id,evt,x,y)end"
+#define GRID_ACTIONSTRING_TOUCH_INIT "--[[@cb]]self.touch_cb=function(self,id,evt,x,y)print(id,evt,x,y)end"
 
 // clang-format on
 


### PR DESCRIPTION
## Summary
- `GRID_ACTIONSTRING_TOUCH_INIT` (added in the ZONA module work, #406) has a stray space after the `--[[@cb]]` marker, unlike every other `GRID_ACTIONSTRING_*_INIT` constant.
- This string is synced into `grid-protocol`'s `grid_protocol_bot.json` by CI, where a test asserts action strings are already in minified form. The space causes the minifier's output to differ from the raw constant, failing `bot-actionstrings.test.ts > GRID_ACTIONSTRING_TOUCH_INIT should be already minified` and blocking grid-protocol's CI (`ci.yml`) and its version/publish pipeline (`version.yml`), both of which run `npm test` unconditionally.

## Fix
Remove the space in `common/src/c/grid_ui_touch.h`:
```
-#define GRID_ACTIONSTRING_TOUCH_INIT "--[[@cb]] self.touch_cb=function(self,id,evt,x,y)print(id,evt,x,y)end"
+#define GRID_ACTIONSTRING_TOUCH_INIT "--[[@cb]]self.touch_cb=function(self,id,evt,x,y)print(id,evt,x,y)end"
```

## Test plan
- [x] Merge, let CI sync `grid_protocol_bot.json` into grid-protocol, confirm `bot-actionstrings.test.ts` passes there